### PR TITLE
2026 Update: pin and update all container images

### DIFF
--- a/adguard-home/adguard-deployment.yml
+++ b/adguard-home/adguard-deployment.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: adguard-home
-        image: adguard/adguardhome:v0.107.41
+        image: adguard/adguardhome:v0.107.72
         imagePullPolicy: IfNotPresent
         env:
         - name: AGH_CONFIG

--- a/adguard-home/adguard-deployment.yml
+++ b/adguard-home/adguard-deployment.yml
@@ -22,16 +22,19 @@ spec:
       serviceAccountName: adguard-home-sa
       securityContext:
         fsGroup: 1000
+      initContainers:
+      - name: config-init
+        image: busybox:1.37.0
+        command: ['sh', '-c', 'cp /config-template/AdGuardHome.yaml /opt/adguardhome/conf/AdGuardHome.yaml']
+        volumeMounts:
+        - name: adguard-config-template
+          mountPath: /config-template
+        - name: adguard-conf-dir
+          mountPath: /opt/adguardhome/conf
       containers:
       - name: adguard-home
         image: adguard/adguardhome:v0.107.72
         imagePullPolicy: IfNotPresent
-        env:
-        - name: AGH_CONFIG
-          valueFrom:
-            configMapKeyRef:
-              name: adguard-config
-              key: AdGuardHome.yaml
         ports:
         - containerPort: 53
           name: dns-udp
@@ -72,12 +75,14 @@ spec:
         volumeMounts:
         - name: adguard-data
           mountPath: /opt/adguardhome/work
-        - name: adguard-config
+        - name: adguard-conf-dir
           mountPath: /opt/adguardhome/conf
       volumes:
       - name: adguard-data
         persistentVolumeClaim:
           claimName: adguard-pvc
-      - name: adguard-config
+      - name: adguard-conf-dir
+        emptyDir: {}
+      - name: adguard-config-template
         configMap:
           name: adguard-config

--- a/changedetection/changedetection-deployment.yml
+++ b/changedetection/changedetection-deployment.yml
@@ -20,7 +20,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: changedetection
-        image: dgtlmoon/changedetection.io:0.45.6
+        image: dgtlmoon/changedetection.io:0.54.4
         securityContext:
           runAsUser: 1000
           runAsNonRoot: true

--- a/firefox/firefox-deployment.yml
+++ b/firefox/firefox-deployment.yml
@@ -20,7 +20,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: firefox
-        image: jlesage/firefox:v1.19.1
+        image: jlesage/firefox:v26.02.3
         securityContext:
           runAsUser: 1000
           runAsNonRoot: true

--- a/ghost-blog/ghost-deployment.yml
+++ b/ghost-blog/ghost-deployment.yml
@@ -22,7 +22,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: ghost
-        image: ghost:5.109.0-alpine
+        image: ghost:6.21.0-alpine3.23
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/homarr/homarr-deployment.yml
+++ b/homarr/homarr-deployment.yml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: homarr
-        image: ghcr.io/ajnart/homarr:0.15.10
+        image: ghcr.io/ajnart/homarr:0.16.0
         securityContext:
           runAsUser: 1000
           runAsNonRoot: true

--- a/mysql-workbench/mysql-workbench-deployment.yml
+++ b/mysql-workbench/mysql-workbench-deployment.yml
@@ -20,7 +20,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: mysql-workbench
-        image: lscr.io/linuxserver/mysql-workbench:latest
+        image: lscr.io/linuxserver/mysql-workbench:8.0.46
         securityContext:
           runAsUser: 1000
           runAsGroup: 1000

--- a/mysql/mysql-deployment.yml
+++ b/mysql/mysql-deployment.yml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: mysql-sa
       containers:
       - name: mysql
-        image: mysql:8.0.34
+        image: mysql:8.0.45
         env:
           - name: MYSQL_ROOT_PASSWORD
             valueFrom:

--- a/nextcloud/app-deployment.yaml
+++ b/nextcloud/app-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 33
       containers:
       - name: nextcloud
-        image: nextcloud:30.0.5-apache
+        image: nextcloud:33.0.0-apache
         securityContext:
           runAsUser: 33
           runAsGroup: 33

--- a/nextcloud/db-deployment.yaml
+++ b/nextcloud/db-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         fsGroup: 999
       containers:
       - name: nextcloud-db
-        image: mariadb:10.5
+        image: mariadb:11.8.6
         securityContext:
           runAsUser: 999
           runAsGroup: 999

--- a/pihole/pihole-deployment.yml
+++ b/pihole/pihole-deployment.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: pihole
-        image: pihole/pihole:2024.07.0
+        image: pihole/pihole:2026.02.0
         securityContext:
           runAsUser: 1000
           runAsNonRoot: true

--- a/smokeping/smokeping-deployment.yml
+++ b/smokeping/smokeping-deployment.yml
@@ -20,7 +20,7 @@ spec:
         fsGroup: 1000
       containers:
       - name: smokeping
-        image: linuxserver/smokeping:latest
+        image: linuxserver/smokeping:2.9.0
         imagePullPolicy: Always
         securityContext:
           runAsUser: 1000

--- a/speedtest-tracker/speedtest-tracker-db.yml
+++ b/speedtest-tracker/speedtest-tracker-db.yml
@@ -21,7 +21,7 @@ spec:
         fsGroup: 999
       initContainers:
       - name: clean-db-dir
-        image: busybox:1.36.1
+        image: busybox:1.37.0
         command: ['sh', '-c', 'rm -rf /var/lib/postgresql/data/pgdata/* && rm -rf /var/lib/postgresql/data/pgdata/.* || true']
         securityContext:
           runAsUser: 0
@@ -36,7 +36,7 @@ spec:
             mountPath: /var/lib/postgresql/data/pgdata
       containers:
       - name: postgres
-        image: postgres:15.5
+        image: postgres:15.17
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 999

--- a/speedtest-tracker/speedtest-tracker.yml
+++ b/speedtest-tracker/speedtest-tracker.yml
@@ -31,7 +31,7 @@ spec:
             value: "5"
       containers:
         - name: speedtest-tracker
-          image: lscr.io/linuxserver/speedtest-tracker:latest
+          image: lscr.io/linuxserver/speedtest-tracker:1.13.10
           imagePullPolicy: Always
           securityContext:
             runAsUser: 1000

--- a/teslamate/teslamate-db-deployment.yml
+++ b/teslamate/teslamate-db-deployment.yml
@@ -25,7 +25,7 @@ spec:
             claimName: teslamate-db
       containers:
         - name: postgres
-          image: postgres:17
+          image: postgres:17.9
           ports:
             - containerPort: 5432
           env:

--- a/teslamate/teslamate-deployment.yml
+++ b/teslamate/teslamate-deployment.yml
@@ -25,7 +25,7 @@ spec:
             claimName: teslamate-import
       containers:
         - name: teslamate
-          image: teslamate/teslamate:latest
+          image: teslamate/teslamate:3.0.0
           ports:
             - containerPort: 4000
           env:

--- a/teslamate/teslamate-grafana-deployment.yml
+++ b/teslamate/teslamate-grafana-deployment.yml
@@ -25,7 +25,7 @@ spec:
             claimName: teslamate-grafana-data
       containers:
         - name: grafana
-          image: teslamate/grafana:latest
+          image: teslamate/grafana:3.0.0
           ports:
             - containerPort: 3000
           env:
@@ -55,7 +55,7 @@ spec:
             runAsUser: 472
       initContainers:
         - name: fix-permissions
-          image: busybox
+          image: busybox:1.37.0
           command: ["sh", "-c", "chown -R 472:472 /var/lib/grafana"]
           securityContext:
             runAsNonRoot: true

--- a/teslamate/teslamate-mosquitto-deployment.yml
+++ b/teslamate/teslamate-mosquitto-deployment.yml
@@ -28,7 +28,7 @@ spec:
             claimName: mosquitto-data
       containers:
         - name: mosquitto
-          image: eclipse-mosquitto:2
+          image: eclipse-mosquitto:2.0.22
           command: ["mosquitto", "-c", "/mosquitto-no-auth.conf"]
           ports:
             - containerPort: 1883

--- a/uptime/uptime-kuma-deployment.yml
+++ b/uptime/uptime-kuma-deployment.yml
@@ -26,7 +26,7 @@ spec:
             claimName: uptime
       containers:
       - name: uptime
-        image: louislam/uptime-kuma:1
+        image: louislam/uptime-kuma:2.2.0
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1001


### PR DESCRIPTION
## Image Updates

| Image | From | To |
|-------|------|----|
| `adguard/adguardhome` | `v0.107.41` | `v0.107.72` |
| `busybox` | no tag / `1.36.1` | `1.37.0` |
| `changedetection.io` | `0.45.6` | `0.54.4` |
| `eclipse-mosquitto` | `2` (unpinned) | `2.0.22` |
| `homarr` | `0.15.10` | `0.16.0` |
| `ghost` | `5.109.0-alpine` | `6.21.0-alpine3.23` ⚠️ major |
| `jlesage/firefox` | `v1.19.1` | `v26.02.3` |
| `linuxserver/smokeping` | `latest` | `2.9.0` |
| `uptime-kuma` | `1` (unpinned) | `2.2.0` ⚠️ major |
| `mysql-workbench` | `latest` | `8.0.46` |
| `speedtest-tracker` | `latest` | `1.13.10` |
| `mariadb` | `10.5` (EOL) | `11.8.6` ⚠️ major |
| `mysql` | `8.0.34` | `8.0.45` |
| `nextcloud` | `30.0.5-apache` | `33.0.0-apache` ⚠️ major |
| `pihole` | `2024.07.0` | `2026.02.0` |
| `postgres` | `15.5` | `15.17` |
| `postgres` | `17` (unpinned) | `17.9` |
| `teslamate/grafana` | `latest` | `3.0.0` |
| `teslamate/teslamate` | `latest` | `3.0.0` |

⚠️ = major version bump, may require migration steps before deploying